### PR TITLE
devmem2 stdout regression

### DIFF
--- a/setPL.sh
+++ b/setPL.sh
@@ -74,7 +74,7 @@ readPhysMemWord() {
     printf -v addrHex "0x%x" $1
     output=$(devmem2 $addrHex w 2>&1)
     if [ $? -eq 0 ]; then
-        retVal=$(echo "$output" | sed -nE 's/Value at address.*: (0x[0-9A-E]+)/\1/p')
+        retVal=$(echo "$output" | sed -nE 's/(Value|Read) at address.*: (0x[0-9A-E]+)/\2/p')
         if [ -z "$retVal" ]; then
             echo "Error parsing devmem2 read output"
             exit 1


### PR DESCRIPTION
In a semi-recent (1.5 years) change to the github version of devmem2, the output of the tool was changed from `"Value at address..."` to `"Read at address"`. This is the relevant commit to devmem2: https://github.com/VCTLabs/devmem2/commit/5a438ff7f7fc40d50f57887a1bddbfc913d08034 

This results in failure to read from devmem2 and the MMIO.

To allow the script to still parse the line correctly, a small regex change is necessary. Now, the script supports both versions of devmem2.